### PR TITLE
[MERGE in 15th Feb 2021] remove user_key(Pardot API authentication with the API key / user key )

### DIFF
--- a/src/main/java/org/embulk/input/pardot/PardotInputPlugin.java
+++ b/src/main/java/org/embulk/input/pardot/PardotInputPlugin.java
@@ -179,17 +179,6 @@ public class PardotInputPlugin
     public static PardotClient getClient(PluginTask task)
     {
         final ConfigurationBuilder configBuilder;
-        if (task.getUserKey().isPresent()) {
-            logger.warn("user_key will deprecate in spring 2021 see https://help.salesforce.com/articleView?id=000353746&type=1&mode=1&language=en_US&utm_source=techcomms&utm_medium=email&utm_campaign=eol");
-            configBuilder = Configuration.newBuilder()
-                    .withUsernameAndPasswordLogin(
-                            task.getUserName(),
-                            task.getPassword(),
-                            task.getUserKey().get()
-                    );
-            return new PardotClient(configBuilder);
-        }
-        logger.info("use client_id / client_secret");
         if (task.getAppClientId().isPresent()
                 && task.getAppClientSecret().isPresent()
                 && task.getBusinessUnitId().isPresent()) {

--- a/src/main/java/org/embulk/input/pardot/PluginTask.java
+++ b/src/main/java/org/embulk/input/pardot/PluginTask.java
@@ -15,10 +15,6 @@ public interface PluginTask extends Task
     @Config("password")
     String getPassword();
 
-    @Config("user_key")
-    @ConfigDefault("null")
-    Optional<String> getUserKey();
-
     @Config("app_client_id")
     @ConfigDefault("null")
     Optional<String> getAppClientId();

--- a/src/test/java/org/embulk/input/pardot/TestPardotInputPlugin.java
+++ b/src/test/java/org/embulk/input/pardot/TestPardotInputPlugin.java
@@ -24,7 +24,7 @@ public class TestPardotInputPlugin
             .build();
 
     @Test
-    public void test__getClient__user_key()
+    public void test__getClient()
     {
         ConfigSource config = loadYamlResource(embulk, "config_test_empty_client_secret.yml");
         PluginTask task = config.loadConfig(PluginTask.class);


### PR DESCRIPTION
https://help.salesforce.com/articleView?id=000353746&language=en_US&mode=1&type=1


> Beginning on February 15, 2021 and coinciding with the Spring ’21 release, Pardot’s user authentication system will be discontinued and all users will be required to use Salesforce single sign-on (SSO). All Pardot users not enabled with Salesforce SSO by February 15, 2021 will lose the ability to log into Pardot until they are connected to a Salesforce user.

![image](https://user-images.githubusercontent.com/1389397/104920909-e46d2480-59db-11eb-920c-ef87095134c6.png)


https://developer.pardot.com/kb/authentication/#via-pardot-api-login-endpoint

> Note: In the Spring '21 and later releases of the Pardot API, authentication with the API key / user key will not be supported.

![image](https://user-images.githubusercontent.com/1389397/104920586-55600c80-59db-11eb-9d05-f3f40cedc27e.png)
